### PR TITLE
feat: Simple shell 0.1

### DIFF
--- a/_getchar.c
+++ b/_getchar.c
@@ -1,0 +1,5 @@
+#include "shell.h"
+int _getchar(char c)
+{
+        return (read(0, &c, 1));
+}

--- a/_putchar.c
+++ b/_putchar.c
@@ -1,0 +1,18 @@
+#include "shell.h"
+/**
+ * _putchar - writes the character c to stdout
+ * @c: The character to print
+ *
+ * Return: On success 1.
+ * On error, -1 is returned, and errno is set appropriately.
+ */
+int _putchar(char c)
+{
+	return (write(1, &c, 1));
+}
+
+void prompt(void)
+{
+	_putchar('$');
+	_putchar(' ');
+}

--- a/fork.c
+++ b/fork.c
@@ -1,0 +1,12 @@
+#include "shell.h"
+
+void exec_child(char *cmd, char *argv[])
+{
+	int status;
+	pid_t child_pid;
+
+	child_pid = fork();
+	if(child_pid == 0)
+		execve(cmd, argv, environ);
+	wait(&status);
+}

--- a/main.c
+++ b/main.c
@@ -1,0 +1,26 @@
+#include "shell.h"
+
+int main(void)
+{
+	ssize_t count;
+	size_t len = 0;
+	char *line = NULL;
+	char *argv[] = {"", NULL};
+
+	prompt();
+	while ((count = getline(&line, &len, stdin)) != -1)
+	{
+		line[count - 1] = '\0';
+		argv[0] = line;
+		if (!_strcmp(line, "exit"))
+		{
+			break;
+		}
+		exec_child(argv[0], argv);
+		prompt();
+	}
+	if (count == -1)
+		_putchar('\n');
+	free(line);
+	return (0);
+}

--- a/main.h
+++ b/main.h
@@ -1,6 +1,0 @@
-#ifndef ALX_HEADER
-#define ALX_HEADER
-
-
-
-#endif

--- a/shell.h
+++ b/shell.h
@@ -1,0 +1,20 @@
+#ifndef ALX_HEADER
+#define ALX_HEADER
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+extern char **environ;
+
+int _putchar(char c);
+size_t _strlen(const char *input);
+int _strcmp(char *s1, char *s2);
+int _getchar(char c);
+void exec_child(char *cmd, char *argv[]);
+void prompt(void);
+
+#endif

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,25 @@
+#include "shell.h"
+
+size_t _strlen(const char *input)
+{
+	size_t count = 0;
+
+	while (*input)
+	{
+		count++;
+		input++;
+	}
+	return (count);
+}
+
+int _strcmp(char *s1, char *s2)
+{
+	while (*s1)
+	{
+		if (*s1 != *s2)
+			return (1);
+		s1++;
+		s2++;
+	}
+	return (0);
+}


### PR DESCRIPTION
The Shell works for simple commands without any arguments. The Shell was tested using the commands "/bin/ls" and "/bin/pwd". It is possible to exit the shell using the shortcut Ctrl + D.

bug - The exit command doesn't work properly.
It runs only when used first or twice in a row. If it's preceeded by another input the program just ignores it. The bug might be caused by the child process.